### PR TITLE
Fixed MongoDB URI env variable

### DIFF
--- a/parse/kontena.yml
+++ b/parse/kontena.yml
@@ -5,7 +5,7 @@ mongodb:
 server:
   image: kontena/parse-server:latest
   environment:
-    - MONGO_URI=%{project}-mongodb.kontena.local/production
+    - MONGO_URI=mongodb://%{project}-mongodb.kontena.local/production
     - KONTENA_LB_INTERNAL_PORT=8080
   secrets:
     - secret: PARSE_MASTER_KEY


### PR DESCRIPTION
MONGO_URI needed "mongodb://". When doing a request to the server with the initial MONGO_URI it would return an internal error (failed to connect to MongoDB).
